### PR TITLE
use own name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,11 +50,12 @@ impl Verbosity {
         }
     }
 
-    /// Initialize `env_logger` and set the log level for the given package.
+    /// Initialize `env_logger` and set the log level for the current package.
     ///
     /// All other modules default to printing warnings.
-    pub fn setup_env_logger(&self, own_pkg_name: &str) -> Result<(), Error> {
+    pub fn setup_env_logger(&self) -> Result<(), Error> {
         let level_filter = self.log_level().to_level_filter();
+        let own_pkg_name = env!("CARGO_PKG_NAME");
         LoggerBuilder::new()
             .filter(Some(&own_pkg_name.replace("-", "_")), level_filter)
             .filter(None, Level::Warn.to_level_filter())


### PR DESCRIPTION
It was surprising to me that `.setup_env_logger()` required arguments to be passed. This patch removes the need for that argument.

I'm not sure if there was some more reasoning behind passing in this argument explicitly, but I feel that if there is a method needed with an explicit name, we could always expose another API.

## Examples
### Example: current
```rust
#[derive(Debug, StructOpt)]
struct Cli {
  #[structopt(flatten)]
  verbosity: clap_verbosity_flag::Verbosity,
}

fn main () {
  let args = Cli::from_args();

  let name = env!("CARGO_PKG_NAME");
  args.verbosity.setup_env_logger(name)?;
}
```

### Example: with this patch
```rust
#[derive(Debug, StructOpt)]
struct Cli {
  #[structopt(flatten)]
  verbosity: clap_verbosity_flag::Verbosity,
}

fn main () {
  let args = Cli::from_args();
  args.verbosity.setup_env_logger()?;
}
```

## Drawbacks
If someone isn't using Cargo the name will not be available. But the same holds true for `Clap`, so I'm not too worried about it ever becoming a problem.

---

Thanks!