### PR TITLE
remove setup_env_logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,4 @@ repository = "https://github.com/rust-clique/clap-verbosity-flag"
 
 [dependencies]
 log = "0.4.1"
-env_logger = "0.5.10"
-failure = "0.1.1"
 structopt = "0.2.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@ extern crate log;
 #[macro_use]
 extern crate structopt;
 
-use env_logger::Builder as LoggerBuilder;
-use failure::Error;
 use log::Level;
 
 /// Easily add a `--verbose` flag to CLIs using Structopt
@@ -48,18 +46,6 @@ impl Verbosity {
             3 => Level::Debug,
             _ => Level::Trace,
         }
-    }
-
-    /// Initialize `env_logger` and set the log level for the given package.
-    ///
-    /// All other modules default to printing warnings.
-    pub fn setup_env_logger(&self, own_pkg_name: &str) -> Result<(), Error> {
-        let level_filter = self.log_level().to_level_filter();
-        LoggerBuilder::new()
-            .filter(Some(&own_pkg_name.replace("-", "_")), level_filter)
-            .filter(None, Level::Warn.to_level_filter())
-            .try_init()?;
-        Ok(())
     }
 }
 


### PR DESCRIPTION
Removes the `setup_env_logger` method in favor of [clap-log-flag](https://github.com/rust-clique/clap-log-flag/). I feel we've talked about this a few times already, but never quite figured out if we wanted to go through with it. I'm putting forward a patch so we can decide on whether or not we should remove it. Closes #7. Thanks!